### PR TITLE
Fixed JS error by adjusting variable name

### DIFF
--- a/js/jquery.tablednd.js
+++ b/js/jquery.tablednd.js
@@ -406,7 +406,7 @@ jQuery.tableDnD = {
             var rowId = rows[i].id;
             if (rowId && table.tableDnDConfig && table.tableDnDConfig.serializeRegexp) {
                 rowId = rowId.match(table.tableDnDConfig.serializeRegexp)[0];
-                result += tableId + '[]=' + rowId;
+                result += paramName + '[]=' + rowId;
             }
         }
         return result;


### PR DESCRIPTION
Name of a variable was changed in a declaration but not where it was used. Changed it there as well now.
