### PR TITLE
We should not assume that jQuery is attached to window

### DIFF
--- a/js/jquery.tablednd.js
+++ b/js/jquery.tablednd.js
@@ -128,7 +128,7 @@ $(document).ready(function () {
     });
 });
 
-window.jQuery.tableDnD = {
+jQuery.tableDnD = {
     /** Keep hold of the current table being dragged */
     currentTable: null,
     /** Keep hold of the current drag object if any */
@@ -651,7 +651,7 @@ window.jQuery.tableDnD = {
     }
 };
 
-window.jQuery.fn.extend(
+jQuery.fn.extend(
     {
         tableDnD             : $.tableDnD.build,
         tableDnDUpdate       : $.tableDnD.updateTables,
@@ -661,4 +661,4 @@ window.jQuery.fn.extend(
     }
 );
 
-}(window.jQuery, window, window.document);
+}(jQuery, window, window.document);


### PR DESCRIPTION
If we try to use TableDnD through a module loader it simply breaks because jQuery is not attached to window and we should not assume it is or will be. With this change, it works in both cases. That's how most plugins do it and that's also how it's done in the official documentation: https://learn.jquery.com/plugins/basic-plugin-creation/

Thank you!
