### PR TITLE
Fix for Firefox - using originalEvent property instead of event

### DIFF
--- a/js/jquery.tablednd.js
+++ b/js/jquery.tablednd.js
@@ -283,10 +283,10 @@ jQuery.tableDnD = {
     },
     /** Get the mouse coordinates from the event (allowing for browser differences) */
     mouseCoords: function(e) {
-        if (event.changedTouches)
+        if (e.originalEvent.changedTouches)
             return {
-                x: event.changedTouches[0].clientX,
-                y: event.changedTouches[0].clientY
+                x: e.originalEvent.changedTouches[0].clientX,
+                y: e.originalEvent.changedTouches[0].clientY
             };
         
         if(e.pageX || e.pageY)


### PR DESCRIPTION
When you initialize drag in Firefox, the following error occurs:

```
ReferenceError: event is not defined
if (event.changedTouches)
```

I've changed the code to use `originalEvent` property of event `e`, which is available both in Chrome and Firefox.