### PR TITLE
Break out check for table.id or config.serializeParamName...

### DIFF
--- a/js/jquery.tablednd.js
+++ b/js/jquery.tablednd.js
@@ -611,9 +611,11 @@ jQuery.tableDnD = {
 
         if (!table)
             table = this.currentTable;
-        if (!table || !table.id || !table.rows || !table.rows.length)
-            return {error: { code: 500, message: "Not a valid table, no serializable unique id provided."}};
-
+        if (!table || !table.rows || !table.rows.length)
+            return {error: { code: 500, message: "Not a valid table."}};
+        if (!table.id && !config.serializeParamName)
+            return {error: { code: 500, message: "No serializable unique id provided."}};
+        
         rows      = config.autoCleanRelations
                         && table.rows
                         || $.makeArray(table.rows);


### PR DESCRIPTION
...into a seperate step and clean up the error messages.

Previously if `config.serializeParamName` was provided but `table.id` wasn't set, `tableData` would error out asking for the `table.id` even though it isn't required since `config.serializeParamName` is set.

Now we only error out if neither `table.id` and `config.serializeParamName` are present.

Fixes: https://github.com/isocra/TableDnD/issues/68